### PR TITLE
Mouse button info for drag

### DIFF
--- a/examples/gestures.rs
+++ b/examples/gestures.rs
@@ -4,14 +4,17 @@ fn main() {
     rui(hstack((
         circle()
             .color(RED_HIGHLIGHT.alpha(0.8))
-            .tap(|_, _| println!("tapped circle"))
+            .tap(|_cx, _key_mods| println!("tapped circle"))
             .padding(Auto),
         state(LocalOffset::zero, |off, cx| {
             rectangle()
                 .corner_radius(5.0)
                 .color(AZURE_HIGHLIGHT.alpha(0.8))
                 .offset(cx[off])
-                .drag(move |cx, delta, _state, _key_mods| cx[off] += delta)
+                .drag(move |cx, delta, _state, _key_mods, mouse_button| {
+                    println!("mouse button {:?}", mouse_button);
+                    cx[off] += delta
+                })
                 .padding(Auto)
         }),
     )));

--- a/examples/key_mods.rs
+++ b/examples/key_mods.rs
@@ -13,7 +13,7 @@ fn main() {
             rectangle()
                 .corner_radius(5.0)
                 .color(AZURE_HIGHLIGHT_BACKGROUND)
-                .drag(|_, delta, _state, key_mods| {
+                .drag(|_, delta, _state, key_mods, _mouse_button| {
                     println!("dragging: {:?}, key modifiers state: {:?}", delta, key_mods)
                 })
                 .padding(Auto),

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use euclid::*;
 use std::any::Any;
 use std::collections::HashMap;
 use std::ops;
+use tao::event::MouseButton;
 
 pub type LocalSpace = vger::defs::LocalSpace;
 pub type WorldSpace = vger::defs::WorldSpace;
@@ -40,6 +41,9 @@ pub struct Context {
     /// Previous touch/mouse positions.
     pub(crate) previous_position: [LocalPoint; 16],
 
+    /// Pressed mouse buton.
+    pub(crate) mouse_button: Option<MouseButton>,
+
     /// Keyboard modifiers state.
     pub(crate) key_mods: ModifiersState,
 
@@ -72,6 +76,7 @@ impl Context {
             touches: [ViewId::default(); 16],
             starts: [LocalPoint::zero(); 16],
             previous_position: [LocalPoint::zero(); 16],
+            mouse_button: None,
             key_mods: ModifiersState::default(),
             root_id: ViewId { id: 1 },
             focused_id: None,

--- a/src/drag.rs
+++ b/src/drag.rs
@@ -1,3 +1,5 @@
+use tao::event::MouseButton;
+
 use crate::*;
 
 pub enum GestureState {
@@ -15,7 +17,7 @@ pub struct Drag<V, F> {
 impl<V, F> Drag<V, F>
 where
     V: View,
-    F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState) + 'static,
+    F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState, Option<MouseButton>) + 'static,
 {
     pub fn new(v: V, f: F) -> Self {
         Self { child: v, func: f }
@@ -25,7 +27,7 @@ where
 impl<V, F> View for Drag<V, F>
 where
     V: View,
-    F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState) + 'static,
+    F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState, Option<MouseButton>) + 'static,
 {
     fn print(&self, id: ViewId, cx: &mut Context) {
         println!("Drag {{");
@@ -45,7 +47,13 @@ where
             EventKind::TouchMove { id } => {
                 if cx.touches[*id] == vid {
                     let delta = event.position - cx.previous_position[*id];
-                    (self.func)(cx, delta, GestureState::Changed, cx.key_mods.clone());
+                    (self.func)(
+                        cx,
+                        delta,
+                        GestureState::Changed,
+                        cx.key_mods.clone(),
+                        cx.mouse_button.clone(),
+                    );
                     cx.previous_position[*id] = event.position;
                 }
             }
@@ -57,6 +65,7 @@ where
                         event.position - cx.previous_position[*id],
                         GestureState::Ended,
                         cx.key_mods.clone(),
+                        cx.mouse_button.clone(),
                     );
                 }
             }

--- a/src/knob.rs
+++ b/src/knob.rs
@@ -18,7 +18,7 @@ pub fn knob_v(value: f32, set_value: impl Fn(f32, &mut Context) + 'static) -> im
     zstack((
         circle()
             .color(CLEAR_COLOR)
-            .drag(move |cx, off, _state, _key_mods| {
+            .drag(move |cx, off, _state, _key_mods, _mouse_button| {
                 set_value((value + (off.x + off.y) / 400.0).clamp(0.0, 1.0), cx);
             }),
         canvas(move |_, sz, vger| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,11 +484,12 @@ pub fn rui(view: impl View) {
                 frame.present();
             }
             tao::event::Event::WindowEvent {
-                event: WindowEvent::MouseInput { state, .. },
+                event: WindowEvent::MouseInput { state, button, .. },
                 ..
             } => {
                 match state {
                     ElementState::Pressed => {
+                        cx.mouse_button = Some(button);
                         let event = Event {
                             kind: EventKind::TouchBegin { id: 0 },
                             position: mouse_position,
@@ -496,6 +497,7 @@ pub fn rui(view: impl View) {
                         view.process(&event, cx.root_id, &mut cx, &mut vger)
                     }
                     ElementState::Released => {
+                        cx.mouse_button = None;
                         let event = Event {
                             kind: EventKind::TouchEnd { id: 0 },
                             position: mouse_position,

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use accesskit::Role;
+use tao::event::MouseButton;
 
 pub trait Modifiers: View + Sized {
     /// Adds space around a view. Can be either `Auto` or `Px(number_of_pixels)`
@@ -16,7 +17,9 @@ pub trait Modifiers: View + Sized {
     fn geom<F: Fn(&mut Context, LocalSize) + 'static>(self, f: F) -> Geom<Self, F>;
 
     /// Calls a function in response to a drag.
-    fn drag<F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState) + 'static>(
+    fn drag<
+        F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState, Option<MouseButton>) + 'static,
+    >(
         self,
         f: F,
     ) -> Drag<Self, F>;
@@ -64,7 +67,9 @@ impl<V: View> Modifiers for V {
     fn geom<F: Fn(&mut Context, LocalSize) + 'static>(self, f: F) -> Geom<Self, F> {
         Geom::new(self, f)
     }
-    fn drag<F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState) + 'static>(
+    fn drag<
+        F: Fn(&mut Context, LocalOffset, GestureState, ModifiersState, Option<MouseButton>) + 'static,
+    >(
         self,
         f: F,
     ) -> Drag<Self, F> {

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -44,7 +44,7 @@ impl<B: Binding<f32>> HSlider<B> {
                         cx[width] = sz.width;
                     }
                 })
-                .drag(move |cx, off, _state, _key_mods| {
+                .drag(move |cx, off, _state, _key_mods, _mouse_button| {
                     value.with_mut(cx, |v| *v = (*v + off.x / w).clamp(0.0, 1.0));
                 })
             },
@@ -113,7 +113,7 @@ where
                         cx[height] = sz.height;
                     }
                 })
-                .drag(move |cx, off, _state, _key_mods| {
+                .drag(move |cx, off, _state, _key_mods, _mouse_button| {
                     (set_value)(cx, (value + off.y / h).clamp(0.0, 1.0));
                 })
             },


### PR DESCRIPTION
Added `MouseButton` to drag view modifier. When mouse is pressed / released, a field in `Context` gets updated. Also adapted the `gestures.rs` example to print the pressed mouse button.