### PR TITLE
Cache layout

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -90,6 +90,9 @@ pub struct Context {
 
     /// State dependencies.
     pub(crate) deps: HashMap<ViewId, Vec<ViewId>>,
+
+    /// A stack of ids for states.
+    pub(crate) id_stack: Vec<ViewId>,
 }
 
 impl Context {
@@ -111,6 +114,7 @@ impl Context {
             env: HashMap::new(),
             dirty_region: Region::EMPTY,
             deps: HashMap::new(),
+            id_stack: vec![],
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -134,6 +134,7 @@ impl Context {
         // If the window size has changed, force a relayout.
         if window_size != self.window_size {
             self.deps.clear();
+            self.window_size = window_size;
         }
 
         // Run any animations.

--- a/src/context.rs
+++ b/src/context.rs
@@ -91,7 +91,7 @@ pub struct Context {
     /// State dependencies.
     pub(crate) deps: HashMap<ViewId, Vec<ViewId>>,
 
-    /// A stack of ids for states.
+    /// A stack of ids for states to get parent dependencies.
     pub(crate) id_stack: Vec<ViewId>,
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -93,6 +93,9 @@ pub struct Context {
 
     /// A stack of ids for states to get parent dependencies.
     pub(crate) id_stack: Vec<ViewId>,
+
+    /// Previous window size.
+    window_size: Size2D<f32, WorldSpace>,
 }
 
 impl Context {
@@ -115,6 +118,7 @@ impl Context {
             dirty_region: Region::EMPTY,
             deps: HashMap::new(),
             id_stack: vec![],
+            window_size: Size2D::default(),
         }
     }
 
@@ -126,6 +130,12 @@ impl Context {
         access_nodes: &mut Vec<accesskit::Node>,
         window_size: Size2D<f32, WorldSpace>,
     ) -> bool {
+
+        // If the window size has changed, force a relayout.
+        if window_size != self.window_size {
+            self.deps.clear();
+        }
+
         // Run any animations.
         view.process(&Event::Anim, self.root_id, self, vger);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -87,6 +87,9 @@ pub struct Context {
 
     /// Regions of window that needs repainting.
     pub(crate) dirty_region: Region<WorldSpace>,
+
+    /// State dependencies.
+    pub(crate) deps: HashMap<ViewId, Vec<ViewId>>,
 }
 
 impl Context {
@@ -107,6 +110,7 @@ impl Context {
             enable_dirty: true,
             env: HashMap::new(),
             dirty_region: Region::EMPTY,
+            deps: HashMap::new(),
         }
     }
 

--- a/src/views/state.rs
+++ b/src/views/state.rs
@@ -67,6 +67,8 @@ where
     fn layout(&self, id: ViewId, sz: LocalSize, cx: &mut Context, vger: &mut Vger) -> LocalSize {
         cx.init_state(id, &self.default);
 
+        cx.id_stack.push(id);
+
         let child_size = (self.func)(State::new(id), cx).layout(id.child(&0), sz, cx, vger);
 
         // Compute layout dependencies.
@@ -83,6 +85,8 @@ where
                 offset: LocalOffset::zero(),
             },
         );
+
+        cx.id_stack.pop();
 
         child_size
     }

--- a/src/views/state.rs
+++ b/src/views/state.rs
@@ -69,6 +69,16 @@ where
 
         let child_size = (self.func)(State::new(id), cx).layout(id.child(&0), sz, cx, vger);
 
+        // Compute layout dependencies.
+        let mut deps = vec![];
+        deps.push(id);
+        (self.func)(State::new(id), cx).gc(id.child(&0), cx, &mut deps);
+
+        cx.deps.insert(
+            id,
+            deps
+        );
+
         cx.layout.insert(
             id,
             LayoutBox {

--- a/src/views/state.rs
+++ b/src/views/state.rs
@@ -69,12 +69,14 @@ where
 
         cx.id_stack.push(id);
 
-        let child_size = (self.func)(State::new(id), cx).layout(id.child(&0), sz, cx, vger);
+        let view = (self.func)(State::new(id), cx);
+
+        let child_size = view.layout(id.child(&0), sz, cx, vger);
 
         // Compute layout dependencies.
         let mut deps = vec![];
         deps.append(&mut cx.id_stack.clone());
-        (self.func)(State::new(id), cx).gc(id.child(&0), cx, &mut deps);
+        view.gc(id.child(&0), cx, &mut deps);
 
         cx.deps.insert(id, deps);
 

--- a/src/views/state.rs
+++ b/src/views/state.rs
@@ -73,7 +73,7 @@ where
 
         // Compute layout dependencies.
         let mut deps = vec![];
-        deps.push(id);
+        deps.append(&mut cx.id_stack.clone());
         (self.func)(State::new(id), cx).gc(id.child(&0), cx, &mut deps);
 
         cx.deps.insert(id, deps);

--- a/src/views/state.rs
+++ b/src/views/state.rs
@@ -74,10 +74,7 @@ where
         deps.push(id);
         (self.func)(State::new(id), cx).gc(id.child(&0), cx, &mut deps);
 
-        cx.deps.insert(
-            id,
-            deps
-        );
+        cx.deps.insert(id, deps);
 
         cx.layout.insert(
             id,


### PR DESCRIPTION
Avoids layout recompilation by storing dependencies on each `state`.