### PR TITLE
fix horizontal list width/height mixup

### DIFF
--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -92,7 +92,7 @@ where
                     x += child_size.width;
                 }
 
-                LocalSize::new(max_height, width_sum)
+                LocalSize::new(width_sum, max_height)
             }
             ListOrientation::Vertical => {
                 let n = self.ids.len() as f32;


### PR DESCRIPTION
I found that a horizontal list will scale vertically instead of horizontally due to wrong order of `LocalSize::new` parameters. Fixed that.