### PR TITLE
Export interface to Vger

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // #![feature(type_alias_impl_trait)]
 
 use vger::color::*;
-use vger::{LineMetrics, PaintIndex, Vger};
+pub use vger::{LineMetrics, PaintIndex, Vger};
 
 #[cfg(feature = "winit")]
 #[macro_use]


### PR DESCRIPTION
Often I find myself in a situation where I need to explicitly reference interface to Vger (usually while declaring a helper function to use in canvas). However, putting vger-rs into `Cargo.toml` and using that often results in type conflicts. The reason for that is a conflict of `vger-rs` versions used in `rui` and that included in the user project.

The best solution I found is in the commit; just `pub use vger::{ .. }`. One day, it might be better to make a submodule in rui, but for my current needs, this worked just fine.