### PR TITLE
Export interface to Vger, vol. 2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // #![feature(type_alias_impl_trait)]
 
 use vger::color::*;
-use vger::{LineMetrics, PaintIndex, Vger};
+pub use vger::{LineMetrics, PaintIndex, Vger};
 
 #[cfg(feature = "winit")]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 // #![feature(type_alias_impl_trait)]
 
+pub use vger;
 use vger::color::*;
-pub use vger::{LineMetrics, PaintIndex, Vger};
+use vger::{LineMetrics, PaintIndex, Vger};
 
 #[cfg(feature = "winit")]
 #[macro_use]


### PR DESCRIPTION
I ran into the need to manually construct the `Color` type, and while I was at it, realized it would be better for rui to expose the whole vger, since it's so central to rendering on `canvas`.

This basically changes the `pub use vger::{ .. };` from the previous pull request to `pub use vger;`