### PR TITLE
Update dependencies to latest upstream (notably winit -> 0.30, wgpu -> 0.20, accesskit -> 0.16)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ euclid = "0.22.7"
 wgpu = "0.20.0"
 futures = "0.3"
 vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
-accesskit = "0.12.0"
+accesskit = "0.13.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,5 @@ log = "0.4"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.76"
 web-sys = { version = "^0.3.61", features = ["Location"] }
-log = "0.4"
 console_log = "0.1.2"
 console_error_panic_hook = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ default = [ "winit" ]
 
 [dependencies]
 euclid = "0.22.7"
-wgpu = "0.19.0"
+wgpu = "0.20.0"
 futures = "0.3"
-vger = { git = "https://github.com/audulus/vger-rs", rev = "fa4a1d4b67a8f6d4a463263652e07bfab99a6caa" }
+vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
 accesskit = "0.11.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ log = "0.4"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.76"
 web-sys = { version = "^0.3.61", features = ["Location"] }
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = [ "winit" ]
 euclid = "0.22.7"
 wgpu = "0.20.0"
 futures = "0.3"
-vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
+vger = "0.3"
 accesskit = "0.16.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ euclid = "0.22.7"
 wgpu = "0.20.0"
 futures = "0.3"
 vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
-accesskit = "0.15.0"
+accesskit = "0.16.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3"
 vger = "0.2.8"
 accesskit = "0.11.0"
 lazy_static = "1.4.0"
-winit = { version = "0.29", optional = true, features = [
+winit = { version = "0.30", optional = true, features = [
     "rwh_05",
  ] }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ log = "0.4"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.76"
 web-sys = { version = "^0.3.61", features = ["Location"] }
-console_log = "0.1.2"
+console_log = "0.2"
 console_error_panic_hook = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ euclid = "0.22.7"
 wgpu = "0.20.0"
 futures = "0.3"
 vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
-accesskit = "0.11.0"
+accesskit = "0.12.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ futures = "0.3"
 vger = "0.2.8"
 accesskit = "0.11.0"
 lazy_static = "1.4.0"
-winit = { version = "0.28.1", optional = true }
+winit = { version = "0.29", optional = true, features = [
+    "rwh_05",
+ ] }
 log = "0.4"
 
 # Seems we can't publish to crates.io with this dependency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,12 @@ default = [ "winit" ]
 
 [dependencies]
 euclid = "0.22.7"
-wgpu = "0.18.0"
+wgpu = "0.19.0"
 futures = "0.3"
-vger = "0.2.8"
+vger = { git = "https://github.com/audulus/vger-rs", rev = "fa4a1d4b67a8f6d4a463263652e07bfab99a6caa" }
 accesskit = "0.11.0"
 lazy_static = "1.4.0"
-winit = { version = "0.30", optional = true, features = [
-    "rwh_05",
- ] }
+winit = { version = "0.30", optional = true }
 log = "0.4"
 
 # Seems we can't publish to crates.io with this dependency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ euclid = "0.22.7"
 wgpu = "0.20.0"
 futures = "0.3"
 vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
-accesskit = "0.13.0"
+accesskit = "0.14.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ euclid = "0.22.7"
 wgpu = "0.20.0"
 futures = "0.3"
 vger = { git = "https://github.com/audulus/vger-rs", rev = "eb4e1f66c638df255171187e09af3a1a09b020fe" }
-accesskit = "0.14.0"
+accesskit = "0.15.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }
 log = "0.4"

--- a/src/context.rs
+++ b/src/context.rs
@@ -40,9 +40,9 @@ pub(crate) type StateMap = HashMap<ViewId, StateHolder>;
 
 pub(crate) type EnvMap = HashMap<TypeId, Box<dyn Any>>;
 
-pub struct RenderInfo<'a> {
+pub struct RenderInfo<'a, 'window> {
     pub device: &'a wgpu::Device,
-    pub surface: &'a wgpu::Surface,
+    pub surface: &'a wgpu::Surface<'window>,
     pub config: &'a wgpu::SurfaceConfiguration,
     pub queue: &'a wgpu::Queue,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -113,8 +113,6 @@ pub struct Context {
     /// Render the dirty rectangle for debugging?
     render_dirty: bool,
 
-    pub(crate) access_node_classes: accesskit::NodeClassSet,
-
     /// Lock the cursor in position. Useful for dragging knobs.
     pub(crate) grab_cursor: bool,
 
@@ -152,7 +150,6 @@ impl Context {
             window_size: Size2D::default(),
             root_offset: LocalOffset::zero(),
             render_dirty: false,
-            access_node_classes: accesskit::NodeClassSet::default(),
             grab_cursor: false,
             prev_grab_cursor: false,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub use vger;
 use vger::color::*;
 pub use vger::{LineMetrics, PaintIndex, Vger};
 
-#[cfg(feature = "winit")]
+#[cfg(all(feature = "winit", not(target_arch = "wasm32")))]
 #[macro_use]
 extern crate lazy_static;
 

--- a/src/viewid.rs
+++ b/src/viewid.rs
@@ -13,7 +13,7 @@ impl ViewId {
     /// Returns the corresponding AccessKit ID. We're assuming
     /// the underlying u64 isn't zero.
     pub fn access_id(&self) -> accesskit::NodeId {
-        accesskit::NodeId(std::num::NonZeroU128::new(self.id as u128).unwrap())
+        accesskit::NodeId(self.id)
     }
 
     pub fn is_default(self) -> bool {

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -214,10 +214,7 @@ where
             .collect();
 
         builder.set_children(children);
-        nodes.push((
-            cx.view_id(path).access_id(),
-            builder.build(&mut cx.access_node_classes),
-        ));
+        nodes.push((cx.view_id(path).access_id(), builder.build()));
         Some(cx.view_id(path).access_id())
     }
 }

--- a/src/views/role.rs
+++ b/src/views/role.rs
@@ -86,7 +86,7 @@ where
             Some(cid) => vec![cid],
             None => vec![],
         });
-        nodes.push((aid, builder.build(&mut cx.access_node_classes)));
+        nodes.push((aid, builder.build()));
         Some(aid)
     }
 }

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -272,7 +272,7 @@ impl<VT: ViewTuple + 'static, D: StackDirection + 'static> View for Stack<VT, D>
         });
         builder.set_children(children);
         let aid = cx.view_id(path).access_id();
-        nodes.push((aid, builder.build(&mut cx.access_node_classes)));
+        nodes.push((aid, builder.build()));
         Some(aid)
     }
 }

--- a/src/views/text.rs
+++ b/src/views/text.rs
@@ -48,7 +48,7 @@ impl View for Text {
         nodes: &mut Vec<(accesskit::NodeId, accesskit::Node)>,
     ) -> Option<accesskit::NodeId> {
         let aid = cx.view_id(path).access_id();
-        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::StaticText);
+        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::Label);
         builder.set_name(self.text.clone());
         nodes.push((aid, builder.build()));
         Some(aid)
@@ -109,7 +109,7 @@ where
         nodes: &mut Vec<(accesskit::NodeId, accesskit::Node)>,
     ) -> Option<accesskit::NodeId> {
         let aid = cx.view_id(path).access_id();
-        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::StaticText);
+        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::Label);
         builder.set_name(format!("{}", self));
         nodes.push((aid, builder.build()));
         Some(aid)

--- a/src/views/text.rs
+++ b/src/views/text.rs
@@ -50,7 +50,7 @@ impl View for Text {
         let aid = cx.view_id(path).access_id();
         let mut builder = accesskit::NodeBuilder::new(accesskit::Role::StaticText);
         builder.set_name(self.text.clone());
-        nodes.push((aid, builder.build(&mut cx.access_node_classes)));
+        nodes.push((aid, builder.build()));
         Some(aid)
     }
 }
@@ -111,7 +111,7 @@ where
         let aid = cx.view_id(path).access_id();
         let mut builder = accesskit::NodeBuilder::new(accesskit::Role::StaticText);
         builder.set_name(format!("{}", self));
-        nodes.push((aid, builder.build(&mut cx.access_node_classes)));
+        nodes.push((aid, builder.build()));
         Some(aid)
     }
 }

--- a/src/views/text.rs
+++ b/src/views/text.rs
@@ -48,7 +48,7 @@ impl View for Text {
         nodes: &mut Vec<(accesskit::NodeId, accesskit::Node)>,
     ) -> Option<accesskit::NodeId> {
         let aid = cx.view_id(path).access_id();
-        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::LabelText);
+        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::StaticText);
         builder.set_name(self.text.clone());
         nodes.push((aid, builder.build(&mut cx.access_node_classes)));
         Some(aid)
@@ -109,7 +109,7 @@ where
         nodes: &mut Vec<(accesskit::NodeId, accesskit::Node)>,
     ) -> Option<accesskit::NodeId> {
         let aid = cx.view_id(path).access_id();
-        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::LabelText);
+        let mut builder = accesskit::NodeBuilder::new(accesskit::Role::StaticText);
         builder.set_name(format!("{}", self));
         nodes.push((aid, builder.build(&mut cx.access_node_classes)));
         Some(aid)

--- a/src/winit_event_loop.rs
+++ b/src/winit_event_loop.rs
@@ -1,21 +1,23 @@
 use crate::*;
 
 use futures::executor::block_on;
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, sync::Arc};
+#[cfg(not(target_arch = "wasm32"))]
+use std::{collections::VecDeque, sync::Mutex};
 
+#[cfg(not(target_arch = "wasm32"))]
+use winit::event_loop::EventLoopProxy;
 use winit::{
     dpi::PhysicalSize,
     event::{
         ElementState, Event as WEvent, MouseButton as WMouseButton, Touch, TouchPhase,
         VirtualKeyCode, WindowEvent,
     },
-    event_loop::{ControlFlow, EventLoop, EventLoopProxy},
+    event_loop::{ControlFlow, EventLoop},
     window::{Window, WindowBuilder},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 type WorkQueue = VecDeque<Box<dyn FnOnce(&mut Context) + Send>>;
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
As noted in [a vger-rs pull request](https://github.com/audulus/vger-rs/pull/20), I'm currently investigating use of rui for a cross-platform application supporting desktop + mobile + web, and built on winit and wgpu. This brings rui's dependencies up to the latest released version, which are the same I'm using in my app.

Note the diff is quite large! The winit API in particular changed significantly between 0.28 and 0.30. I've tried to keep the same business logic, and the API is unchanged even though some upstream improvements might want to be reflected in rui's API.

Of particular note, the way winit handles keyboard input has been completely rewritten and supports significantly more than is exposed by rui. I have updated the `rui()` application runner to use these new APIs, but with the same old exposed input interface. One area in which this might actually be an issue is with multi-code-point character input. Rui's API sends a single character per keystroke, whereas winit sends a string. This is because some characters in some input schemes may not reduce down to a single Unicode glyph, instead using combining character codes. The new interface (which uses winit to do key -> character transformation rather than hard coding it as rui did before) will just send on only the first Unicode code point.

Also: the vger dependency is hard-coded to the latest trunk commit as of the time of this writing, rather than a proper crates.io release. Vger should probably have a 0.3 release (since updating wgpu is breaking for downstream apps), and then rui semver-pegs to that.