### PR TITLE
Update wgpu 0.20 -> 22 && vger 0.3 -> 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ default = [ "winit" ]
 
 [dependencies]
 euclid = "0.22.7"
-wgpu = "0.20.0"
+wgpu = "22"
 futures = "0.3"
-vger = "0.3"
+vger = "0.4"
 accesskit = "0.16.0"
 lazy_static = "1.4.0"
 winit = { version = "0.30", optional = true }

--- a/src/winit_event_loop.rs
+++ b/src/winit_event_loop.rs
@@ -99,6 +99,7 @@ async fn setup(window: Arc<Window>) -> DrawContext {
                 label: None,
                 required_features: wgpu::Features::default(),
                 required_limits: wgpu::Limits::default(),
+                memory_hints: wgpu::MemoryHints::Performance,
             },
             trace_dir.ok().as_ref().map(std::path::Path::new),
         )


### PR DESCRIPTION
With vger having released a new version with wgpu v22[1], it is time to update rui's dependencies as well. This patch updates the vger dependency to 0.4, and the pegged wgpu version to 22. The only code change required was in the winit logic, which requires you to hint for optimizing for either `Performance` or `MemoryUsage`. I chose `Performance`.

Since many vger applications (including my own) create and manage wgpu devices and render contexts themselves, updating the wgpu dependency is a breaking change for them. I recommend doing a new major release of rui.

[1]: https://github.com/audulus/vger-rs/pull/21