### PR TITLE
Changed from String to Arc<str> where value is constant + Touch documentation

### DIFF
--- a/examples/flip_cards/src/main.rs
+++ b/examples/flip_cards/src/main.rs
@@ -3,6 +3,7 @@ use rust_search::SearchBuilder;
 use serde_json::{Map, Value};
 use std::collections::{HashSet, VecDeque};
 use std::fs;
+use std::sync::Arc;
 
 // Function to find and extract flip cards from JSON data
 fn find_flip_cards(value: &Value) -> Vec<Value> {
@@ -74,8 +75,8 @@ fn find_flip_cards(value: &Value) -> Vec<Value> {
 #[derive(Clone)]
 struct FlipCardState {
     show_answer: bool,
-    question: String,
-    answer: String,
+    question: Arc<str>,
+    answer: Arc<str>,
 }
 
 // Struct to represent the state of all flip cards
@@ -114,8 +115,8 @@ fn main() {
                     .iter()
                     .map(|card| FlipCardState {
                         show_answer: false,
-                        question: card["q"].as_str().unwrap().to_string(),
-                        answer: card["a"].as_str().unwrap().to_string(),
+                        question: card["q"].to_string().into(),
+                        answer: card["a"].to_string().into(),
                     })
                     .collect(),
                 current_index: 0, // Start at the first card
@@ -128,9 +129,9 @@ fn main() {
                 // Render the current flip card
                 vstack((
                     text(if current_card.show_answer {
-                        current_card.answer.as_str()
+                        &current_card.answer
                     } else {
-                        current_card.question.as_str()
+                        &current_card.question
                     })
                     .font_size(12)
                     .padding(Auto),

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,6 +5,7 @@ use std::any::TypeId;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::ops;
+use std::sync::Arc;
 
 pub type LocalSpace = vger::defs::LocalSpace;
 pub type WorldSpace = vger::defs::WorldSpace;
@@ -19,7 +20,7 @@ pub type WorldToLocal = Transform2D<f32, WorldSpace, LocalSpace>;
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct CommandInfo {
-    pub path: String,
+    pub path: Arc<str>,
     pub key: Option<HotKey>,
 }
 
@@ -81,7 +82,7 @@ pub struct Context {
     pub(crate) focused_id: Option<ViewId>,
 
     /// The current title of the window
-    pub window_title: String,
+    pub window_title: Arc<str>,
 
     /// Are we fullscreen?
     pub fullscreen: bool,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::*;
 
 /// User interface event.
@@ -29,7 +31,7 @@ pub enum Event {
     MouseLeftWindow,
 
     /// Menu command.
-    Command(String),
+    Command(Arc<str>),
 
     /// Key press.
     Key(Key),

--- a/src/views/command.rs
+++ b/src/views/command.rs
@@ -1,10 +1,10 @@
 use crate::*;
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 
 #[derive(Clone)]
 pub struct Command<V, F> {
     child: V,
-    name: String,
+    name: Arc<str>,
     key: Option<HotKey>,
     func: F,
 }
@@ -14,7 +14,7 @@ where
     V: View,
     F: Fn(&mut Context) + Clone + 'static,
 {
-    pub fn new(v: V, name: String, key: Option<HotKey>, f: F) -> Self {
+    pub fn new(v: V, name: Arc<str>, key: Option<HotKey>, f: F) -> Self {
         Self {
             child: v,
             name,
@@ -97,7 +97,7 @@ impl<V, F> private::Sealed for Command<V, F> {}
 
 pub trait DynCommandBase {
     fn exec(&self);
-    fn name(&self) -> String;
+    fn name(&self) -> Arc<str>;
     fn key(&self) -> Option<HotKey>;
 }
 
@@ -337,7 +337,7 @@ impl<V, C> private::Sealed for CommandGroup<V, C> {}
 
 #[derive(Clone)]
 pub struct NullCommand {
-    name: String,
+    name: Arc<str>,
     key: Option<HotKey>,
 }
 
@@ -351,7 +351,7 @@ pub fn command(name: &str) -> NullCommand {
 
 impl DynCommandBase for NullCommand {
     fn exec(&self) {}
-    fn name(&self) -> String {
+    fn name(&self) -> Arc<str> {
         self.name.clone()
     }
     fn key(&self) -> Option<HotKey> {
@@ -379,7 +379,7 @@ impl NullCommand {
 
 #[derive(Clone)]
 pub struct Command2<F> {
-    name: String,
+    name: Arc<str>,
     key: Option<HotKey>,
     func: F,
 }
@@ -391,7 +391,7 @@ where
     fn exec(&self) {
         (self.func)();
     }
-    fn name(&self) -> String {
+    fn name(&self) -> Arc<str> {
         self.name.clone()
     }
     fn key(&self) -> Option<HotKey> {

--- a/src/views/text.rs
+++ b/src/views/text.rs
@@ -106,7 +106,7 @@ macro_rules! impl_text {
                 let txt = &format!("{}", self);
                 let vger = &mut args.vger;
                 let origin = vger.text_bounds(txt, Text::DEFAULT_SIZE, None).origin;
-        
+
                 vger.save();
                 vger.translate([-origin.x, -origin.y]);
                 vger.text(txt, Text::DEFAULT_SIZE, TEXT_COLOR, None);
@@ -116,7 +116,7 @@ macro_rules! impl_text {
                 let txt = &format!("{}", self);
                 (args.text_bounds)(txt, Text::DEFAULT_SIZE, None).size
             }
-        
+
             fn access(
                 &self,
                 path: &mut IdPath,
@@ -131,8 +131,7 @@ macro_rules! impl_text {
             }
         }
 
-        impl TextModifiers for $ty
-        {
+        impl TextModifiers for $ty {
             fn font_size(self, size: u32) -> Text {
                 Text {
                     text: format!("{}", self),
@@ -159,8 +158,7 @@ macro_rules! impl_text {
                 }
             }
         }
-
-    }
+    };
 }
 
 // XXX: this used to be generic for any Display but
@@ -205,8 +203,7 @@ impl DynView for &'static str {
     }
 }
 
-impl TextModifiers for &'static str
-{
+impl TextModifiers for &'static str {
     fn font_size(self, size: u32) -> Text {
         Text {
             text: format!("{}", self),

--- a/src/views/touch.rs
+++ b/src/views/touch.rs
@@ -1,14 +1,21 @@
 use crate::*;
 use std::any::Any;
 
+#[derive(Clone, PartialEq)]
 pub enum TouchState {
     Begin,
     End,
 }
 
+#[derive(Clone)]
 pub struct TouchInfo {
+    /// The position of the touch in local space of the view that received the touch.
     pub pt: LocalPoint,
+
+    /// The mouse button that was used for the touch if a mouse was used.
     pub button: Option<MouseButton>,
+
+    /// The state of the touch. IE: Begin or End.
     pub state: TouchState,
 }
 

--- a/src/views/window.rs
+++ b/src/views/window.rs
@@ -1,11 +1,11 @@
 use crate::*;
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 
 /// Struct for the `window_title` modifier.
 #[derive(Clone)]
 pub struct TitleView<V> {
     child: V,
-    title: String,
+    title: Arc<str>,
 }
 
 impl<V> TitleView<V>

--- a/src/winit_event_loop.rs
+++ b/src/winit_event_loop.rs
@@ -157,7 +157,7 @@ struct EventHandler<T>
 where
     T: View,
 {
-    title: String,
+    title: Arc<str>,
     running: bool,
     // The GPU resources, if running.
     context: Option<DrawContext>,
@@ -189,7 +189,7 @@ where
         self.running = true;
 
         // Create the main window.
-        let window_attributes = Window::default_attributes().with_title(&self.title);
+        let window_attributes = Window::default_attributes().with_title(self.title.to_string());
         self.window = match event_loop.create_window(window_attributes) {
             Err(e) => {
                 log::error!("Error creating window: {:?}", e);
@@ -500,7 +500,7 @@ pub fn rui(view: impl View) {
 
     let window_title = String::from("rui");
     let mut app = EventHandler {
-        title: window_title,
+        title: window_title.into(),
         running: false,
         context: None,
         window: None,


### PR DESCRIPTION
We've switched from `String` to `Arc<str>` for constant values, and it's mainly about performance:

1. **Reduced Memory Allocation:**
   - With `String`, we end up allocating and deallocating memory every time a new string is created or dropped. For values that don’t change, this is unnecessary overhead.
   - By using `Arc<str>`, we share the same string across different parts of the code, cutting down on these allocations.

2. **Avoiding Unnecessary Copies:**
   - `String` requires cloning if it’s being passed around multiple places, which increases memory usage and adds a performance hit.
   - `Arc<str>` lets us share the same data without copying, thanks to its reference counting.

3. **Thread-Safe and Efficient:**
   - `Arc<str>` is thread-safe, so we can safely use the same string across multiple threads without extra locking, which is especially useful when the data is constant and won’t change.

Overall, this change helps make the code faster and more memory efficient by avoiding redundant allocations and copying, while keeping things thread-safe.

**Note**
*The creator of this pull request states that it is ready to be merged from his side.*