### PR TITLE
key and drag pass events to child

### DIFF
--- a/src/views/drag.rs
+++ b/src/views/drag.rs
@@ -26,8 +26,10 @@ pub struct DragFunc<F> {
     pub f: F,
 }
 
-impl<A: 'static, F: Fn(&mut Context, LocalOffset, GestureState, Option<MouseButton>) -> A + Clone> DragFn
-    for DragFunc<F>
+impl<
+        A: 'static,
+        F: Fn(&mut Context, LocalOffset, GestureState, Option<MouseButton>) -> A + Clone,
+    > DragFn for DragFunc<F>
 {
     fn call(
         &self,
@@ -47,8 +49,10 @@ pub struct DragFuncP<F> {
     pub f: F,
 }
 
-impl<A: 'static, F: Fn(&mut Context, LocalPoint, GestureState, Option<MouseButton>) -> A + Clone> DragFn
-    for DragFuncP<F>
+impl<
+        A: 'static,
+        F: Fn(&mut Context, LocalPoint, GestureState, Option<MouseButton>) -> A + Clone,
+    > DragFn for DragFuncP<F>
 {
     fn call(
         &self,
@@ -183,7 +187,11 @@ where
                     );
                 }
             }
-            _ => (),
+            _ => {
+                path.push(0);
+                self.child.process(event, path, cx, actions);
+                path.pop();
+            }
         }
     }
 

--- a/src/views/key.rs
+++ b/src/views/key.rs
@@ -47,19 +47,27 @@ where
     fn process(
         &self,
         event: &Event,
-        _path: &mut IdPath,
+        path: &mut IdPath,
         cx: &mut Context,
         actions: &mut Vec<Box<dyn Any>>,
     ) {
         match self.kind {
             KeyViewKind::Pressed => {
                 if let Event::Key(key) = &event {
-                    actions.push(Box::new((self.func)(cx, key.clone())));
+                    actions.push(Box::new((self.func)(cx, *key)));
+                } else {
+                    path.push(0);
+                    self.child.process(event, path, cx, actions);
+                    path.pop();
                 }
             }
             KeyViewKind::Released => {
                 if let Event::KeyReleased(key) = &event {
-                    actions.push(Box::new((self.func)(cx, key.clone())));
+                    actions.push(Box::new((self.func)(cx, *key)));
+                } else {
+                    path.push(0);
+                    self.child.process(event, path, cx, actions);
+                    path.pop();
                 }
             }
         }


### PR DESCRIPTION
I noticed that nested `KeyView` and `Drag` don't pass events to each other (for example, `Drag` consumes touch events and discards other events). I made them so they pass unprocessed events to their children.